### PR TITLE
Split GPG depends on zenity for user prompts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,5 @@ Homepage: http://www.qubes-os.org
 Package: qubes-gpg-split
 Section: admin
 Architecture: amd64
-Depends: gpgv, ${misc:Depends}
+Depends: gpgv, zenity, ${misc:Depends}
 Description: The Qubes service for secure gpg separation


### PR DESCRIPTION
Without it, it fails to create the prompt in the backend VM that allows the user to authorize access to the keys to a frontend VM.