### PR TITLE
Use gpg2 by default

### DIFF
--- a/qubes.Gpg.service
+++ b/qubes.Gpg.service
@@ -1,2 +1,2 @@
 notify-send "Keyring access from domain: $QREXEC_REMOTE_DOMAIN"
-/usr/lib/qubes-gpg-split/gpg-server /usr/bin/gpg $QREXEC_REMOTE_DOMAIN
+/usr/lib/qubes-gpg-split/gpg-server /usr/bin/gpg2 $QREXEC_REMOTE_DOMAIN


### PR DESCRIPTION
Enigmail will soon cease to work with gpg 1.x and will work only with gpg 2.0 or higher.