### PR TITLE
Use gpg2 in GpgImportKey

### DIFF
--- a/qubes.GpgImportKey.service
+++ b/qubes.GpgImportKey.service
@@ -1,1 +1,1 @@
-/bin/gpg --import
+/bin/gpg2 --import


### PR DESCRIPTION
There was an inconsistency in gpg versions between 'qubes.Gpg.service' and 'qubes.GpgImportKey.service'

Fixes https://github.com/QubesOS/qubes-issues/issues/1874