### PR TITLE
Readme and Manpages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 rpm/
 deb/
 pkgs/
+*.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: required
 dist: trusty
 language: generic
 install: git clone https://github.com/QubesOS/qubes-builder ~/qubes-builder
-# debootstrap in trusty is old...
-before_script: sudo ln -s sid /usr/share/debootstrap/scripts/stretch
 script: ~/qubes-builder/scripts/travis-build
 env:
  - DIST_DOM0=fc20 USE_QUBES_REPO_VERSION=3.1

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ VERSION := $(shell cat version)
 
 help:
 	@echo "Qubes addons main Makefile:" ;\
-	    echo "make rpms                 <--- make rpms and sign them";\
-	    echo; \
-	    echo "make clean                <--- clean all the binary files";\
-	    echo "make update-repo-current  <-- copy newly generated rpms to qubes yum repo";\
-	    echo "make update-repo-current-testing <-- same, but for -current-testing repo";\
-	    echo "make update-repo-unstable <-- same, but to -testing repo";\
-	    echo "make update-repo-installer -- copy dom0 rpms to installer repo"
-	    @exit 0;
+		echo "make rpms                 <--- make rpms and sign them";\
+		echo; \
+		echo "make clean                <--- clean all the binary files";\
+		echo "make update-repo-current  <-- copy newly generated rpms to qubes yum repo";\
+		echo "make update-repo-current-testing <-- same, but for -current-testing repo";\
+		echo "make update-repo-unstable <-- same, but to -testing repo";\
+		echo "make update-repo-installer -- copy dom0 rpms to installer repo"
+		@exit 0;
 
 rpms: rpms-vm
 
@@ -75,6 +75,7 @@ update-repo-installer:
 
 build:
 	$(MAKE) -C src
+	$(MAKE) -C doc manpages
 
 install-vm:
 	install -d $(DESTDIR)/usr/lib/qubes-gpg-split
@@ -88,6 +89,8 @@ install-vm:
 	install -d $(DESTDIR)/var/run/qubes-gpg-split
 	install -D qubes-gpg-split.tmpfiles $(DESTDIR)/etc/tmpfiles.d/qubes-gpg-split.conf
 	make -C tests install-vm
+	make -C doc install
 
 clean:
 	$(MAKE) -C src clean
+	$(MAKE) -C doc clean

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+Qubes Split GPG
+===============
+Split GPG implements a concept similar to having a smart card with your private 
+GPG keys, except that the role of the “smart card” plays another Qubes AppVM. 
+This way one, not-so-trusted domain, e.g. the one where Thunderbird is running, 
+can delegate all crypto operations, such as encryption/decryption and signing to
+another, more trusted, network-isolated, domain. This way the compromise of your
+domain where Thunderbird or another client app is running – arguably a 
+not-so-unthinkable scenario – does not allow the attacker to automatically also
+steal all your keys. (We should make a rather obvious comment here that the 
+so-often-used passphrases on private keys are pretty meaningless because the 
+attacker can easily set up a simple backdoor which would wait until the user 
+enters the passphrase and steal the key then.)
+
+More in-depth usage information can be found 
+[here](https://www.qubes-os.org/doc/split-gpg/).

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qubes-gpg-split
 Section: admin
 Priority: extra
 Maintainer: Jason Mehring <nrgaway@gmail.com>
-Build-Depends: debhelper (>= 9~), quilt
+Build-Depends: debhelper (>= 9~), pandoc, quilt
 Standards-Version: 3.9.5
 Homepage: http://www.qubes-os.org
 

--- a/debian/qubes-gpg-split.install
+++ b/debian/qubes-gpg-split.install
@@ -7,3 +7,6 @@ etc/qubes-rpc/qubes.Gpg
 etc/qubes-rpc/qubes.GpgImportKey
 etc/profile.d/qubes-gpg.sh
 etc/tmpfiles.d/qubes-gpg-split.conf
+usr/share/man/man1/qubes-gpg-client.1.gz
+usr/share/man/man1/qubes-gpg-client-wrapper.1.gz
+usr/share/man/man1/qubes-gpg-import-key.1.gz

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,0 +1,22 @@
+PANDOC=pandoc -s -f rst -t man
+
+DOCS=$(patsubst %.rst,%.1.gz,$(wildcard *.rst))
+
+help:
+	@echo "make manpages			-- generate manpages"
+	@echo "make install			-- generate manpages and copy them to /usr/share/man"
+
+manpages: $(DOCS)
+
+install: manpages
+	install -d $(DESTDIR)/usr/share/man/man1
+	install -D $(DOCS) $(DESTDIR)/usr/share/man/man1/
+
+%.1: %.rst
+	$(PANDOC) $< > $@
+
+%.1.gz: %.1
+	gzip -f $<
+
+clean:
+	rm -f $(DOCS)

--- a/doc/qubes-gpg-client-wrapper.rst
+++ b/doc/qubes-gpg-client-wrapper.rst
@@ -1,0 +1,23 @@
+===========================
+qubes-gpg-client-wrapper(1)
+===========================
+
+NAME
+====
+qubes-gpg-client-wrapper - a wrapper around qubes-gpg-client and qubes-gpg-import-key
+
+SYNOPSIS
+========
+| qubes-gpg-client-wrapper <gpg2 options>
+
+DESCRIPTION
+===========
+qubes-gpg-client-wrapper wraps around qubes-gpg-client and qubes-gpg-import-key
+to better mimic the functionality provided by native gpg2. This overall allows
+qubes-gpg-client-wrapper to be used as a drop in replacement for programs like
+Enigmail and git.
+
+AUTHORS
+=======
+| Marek Marczykowski <marmarek at invisiblethingslab dot com>
+

--- a/doc/qubes-gpg-client.rst
+++ b/doc/qubes-gpg-client.rst
@@ -1,0 +1,185 @@
+===================
+QUBES-GPG-CLIENT(1)
+===================
+
+NAME
+====
+qubes-gpg-client - communicates with a seperate GPG Qube to enable Qubes Split GPG
+
+SYNOPSIS
+========
+| qubes-gpg-client <gpg2 options>
+
+DESCRIPTION
+===========
+qubes-gpg-client functions similarly to gpg2, but performs all sensitive tasks
+in a trusted Qube, defined by $QUBES_GPG_DOMAIN. Options involving network
+connectivity (key servers, etc) are not supported, as the trusted GPG Qube is
+intended to not have network connectivity.
+
+OPTIONS
+=======
+Listed are the options that can be passed to the GPG Qube. More information can be
+found about their functionality in the gpg2 manpage.
+
+-b, --detach-sign
+
+-a, --armor
+
+-c, --symmetric
+
+-d, --decrypt
+
+-e, --encrypt
+
+-k, --list-keys
+
+-K, --list-secret-keys
+
+-n, --dry-run
+
+-o, --output
+
+-q, --quiet
+
+-r, --recipient
+
+-R, --hidden-recipient
+
+-s, --sign
+
+-t, --textmode
+
+-u, --local-user
+
+-v, --verbose
+
+--always-trust
+
+--batch
+
+--cert-digest-algo
+
+--charset
+
+--cipher-algo
+
+--clearsign
+
+--command-fd
+
+--comment
+
+--compress-algo
+
+--digest-algo
+
+--disable-cipher-algo
+
+--disable-mdc
+
+--disable-pubkey-algo
+
+--display-charset
+
+--emit-version
+
+--enable-progress-filter
+
+--encrypt-to
+
+--export
+
+--fingerprint
+
+--fixed-list-mode
+
+--fixed-list-mode
+
+--force-mdc
+
+--force-v3-sigs
+
+--force-v4-certs
+
+--gnupg
+
+--list-config
+
+--list-only
+
+--list-public-keys
+
+--list-sigs
+
+--max-output
+
+--no-comments
+
+--no-encrypt-to
+
+--no-emit-version
+
+--no-force-v3-sigs
+
+--no-force-v4-certs
+
+--no-greeting
+
+--no-secmem-warning
+
+--no-tty
+
+--no-verbose
+
+--openpgp
+
+--personal-cipher-preferences
+
+--personal-compress-preferences
+
+--personal-digest-preferences
+
+--pgp2
+
+--pgp6
+
+--pgp7
+
+--pgp8
+
+--rfc1991
+
+--rfc2440
+
+--rfc4880
+
+--s2k-cipher-algo
+
+--s2k-count
+
+--s2k-digest-algo
+
+--s2k-mode
+
+--status-fd
+
+--store
+
+--trust-model
+
+--use-agent
+
+--verify
+
+--version
+
+--with-colons
+
+--with-fingerprint
+
+--with-keygrip
+
+AUTHORS
+=======
+| Marek Marczykowski <marmarek at invisiblethingslab dot com>

--- a/doc/qubes-gpg-import-key.rst
+++ b/doc/qubes-gpg-import-key.rst
@@ -1,0 +1,21 @@
+=======================
+qubes-gpg-import-key(1)
+=======================
+
+NAME
+====
+qubes-gpg-import-key - imports a GPG key to the GPG Qube's keyring
+
+SYNOPSIS
+========
+| qubes-gpg-import-key <keyfile>
+
+DESCRIPTION
+===========
+qubes-gpg-import-key imports the passed key to the keyring of the GPG Qube, using
+Qubes RPC. This will cause a prompt in dom0 to confirm the import before
+proceeding.
+
+AUTHORS
+=======
+| Marek Marczykowski <marmarek at invisiblethingslab dot com>

--- a/rpm_spec/gpg-split.spec
+++ b/rpm_spec/gpg-split.spec
@@ -34,6 +34,8 @@ Vendor:		Invisible Things Lab
 License:	GPL
 URL:		http://www.qubes-os.org
 
+BuildRequires: pandoc
+
 Requires:	gnupg2
 Requires:   zenity
 
@@ -79,6 +81,9 @@ rm -rf $RPM_BUILD_ROOT
 /etc/profile.d/qubes-gpg.sh
 %dir %attr(0777,root,root) /var/run/qubes-gpg-split
 /etc/tmpfiles.d/qubes-gpg-split.conf
+%{_mandir}/man1/qubes-gpg-client.1*
+%{_mandir}/man1/qubes-gpg-client-wrapper.1*
+%{_mandir}/man1/qubes-gpg-import-key.1*
 
 %files tests
 /usr/lib/qubes-gpg-split/test_thunderbird.py*


### PR DESCRIPTION
Added a basic README (pulled from the first paragraph of the web documentation) and added manpages for qubes-gpg-client, qubes-gpg-client-wrapper, and qubes-gpg-import-key. This PR is part of QubesOS/qubes-issues#2528