### PR TITLE
Added pandoc to Archlinux package dependencies

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -7,7 +7,7 @@ arch=("x86_64")
 url="http://qubes-os.org/"
 license=('GPL')
 depends=('gnupg' 'zenity')
-makedepends=(pkg-config make gcc)
+makedepends=(pkg-config make gcc pandoc)
 
 changelog=debian/changelog
 source=()


### PR DESCRIPTION
Adding manpages broke the Archlinux build, adding pandoc to the dependency list fixes the build.