### PR TITLE
Print to standard out if output is '-'

### DIFF
--- a/gpg-client-wrapper
+++ b/gpg-client-wrapper
@@ -64,7 +64,7 @@ done
 
 . /etc/profile.d/qubes-gpg.sh
 # 63 is $fd_for_stdout but bush seems to reject variables here
-if ! ((output)); then
+if  ! (($output)) || [ "$target" = "-" ] ; then
     exec qubes-gpg-client "${options[@]}" 63>&1
 else
     exec qubes-gpg-client "${options[@]}" 63>&1 >"$target"


### PR DESCRIPTION
The manpage for gpg states if the output specified is '-', print to standard out. This change makes gpg-client-wrapper also respect that option.