### PR TITLE
Add expire time to GPG access notifications

### DIFF
--- a/qubes.Gpg.service
+++ b/qubes.Gpg.service
@@ -1,2 +1,2 @@
-notify-send "Keyring access from domain: $QREXEC_REMOTE_DOMAIN"
+notify-send "Keyring access from domain: $QREXEC_REMOTE_DOMAIN" --expire-time=1000
 /usr/lib/qubes-gpg-split/gpg-server /usr/bin/gpg2 $QREXEC_REMOTE_DOMAIN


### PR DESCRIPTION
Without a set expire time, notifications will hang around forever until the user clicks on them to remove them. Adding this makes them disappear after a short time as expected.