### PR TITLE
Fix archlinux package - remove /var/run

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -20,7 +20,10 @@ build() {
 
 package() {
   cd ..
-  make install-vm DESTDIR=$pkgdir LIBDIR=/usr/lib USRLIBDIR=/usr/lib SYSLIBDIR=/usr/lib
+  make install-vm DESTDIR="$pkgdir" LIBDIR=/usr/lib USRLIBDIR=/usr/lib SYSLIBDIR=/usr/lib
+
+  # Archlinux packaging guidelines: /var/run is a symlink to a tmpfs. Don't create it
+  rm -r "$pkgdir/var/run"
 }
 
 # vim:set ts=2 sw=2 et:

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,6 +1,8 @@
+#!/bin/bash
 # Contributor: Jacob Jenner Rasmussen <jacob@jener.dk>
+# shellcheck disable=SC2034
 pkgname=qubes-split
-pkgver=`cat version`
+pkgver=$(cat version)
 pkgrel=1
 pkgdesc="The Qubes service for secure gpg seperation"
 arch=("x86_64")
@@ -14,16 +16,17 @@ source=()
 md5sums=()
 
 build() {
-	make clean
-	make
+    make clean
+    make
 }
 
 package() {
-  cd ..
-  make install-vm DESTDIR="$pkgdir" LIBDIR=/usr/lib USRLIBDIR=/usr/lib SYSLIBDIR=/usr/lib
+    cd ..
+    # shellcheck disable=SC2154
+    make install-vm DESTDIR="$pkgdir" LIBDIR=/usr/lib USRLIBDIR=/usr/lib SYSLIBDIR=/usr/lib
 
-  # Archlinux packaging guidelines: /var/run is a symlink to a tmpfs. Don't create it
-  rm -r "$pkgdir/var/run"
+    # Archlinux packaging guidelines: /var/run is a symlink to a tmpfs. Don't create it
+    rm -r "$pkgdir/var/run"
 }
 
-# vim:set ts=2 sw=2 et:
+# vim:set ts=4 sw=4 et:


### PR DESCRIPTION
Without this change the package builds successfully but there is a file conflict error when installing it.

I'm not sure that this is the best way to fix the issue, but I don't know enough about the builds for other distros and do not want to mess them up. Since it's used in [core-agent-linux](https://github.com/QubesOS/qubes-core-agent-linux/blob/master/archlinux/PKGBUILD#L104-L105), I assume it's OK.