### PR TITLE
archlinux: rename package to follow other distributions naming

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Contributor: Jacob Jenner Rasmussen <jacob@jener.dk>
 # shellcheck disable=SC2034
-pkgname=qubes-split
+pkgname=qubes-gpg-split
 pkgver=$(cat version)
 pkgrel=1
 pkgdesc="The Qubes service for secure gpg seperation"


### PR DESCRIPTION
Replacement for https://github.com/QubesOS/qubes-app-linux-split-gpg/pull/13.

The builder-archlinux component (https://github.com/QubesOS/qubes-builder-archlinux/pull/19) needs to be changed to add this package into the local repository (qubes-vm* convention is currently followed).

