### PR TITLE
Wait for GUI session before asking the user for confirmation

### DIFF
--- a/qubes.Gpg.service
+++ b/qubes.Gpg.service
@@ -7,6 +7,7 @@ stat_file="/var/run/qubes-gpg-split/stat.$QREXEC_REMOTE_DOMAIN"
 stat_time=$(stat -c %Y "$stat_file" 2>/dev/null || echo 0)
 now=$(date +%s)
 if [ $(($stat_time + $QUBES_GPG_AUTOACCEPT)) -lt "$now" ]; then
+    echo $USER | /etc/qubes-rpc/qubes.WaitForSession >/dev/null 2>/dev/null
     msg_text="Do you allow VM '$QREXEC_REMOTE_DOMAIN' to access your GPG keys "
     msg_text="$msg_text (now and for the following $QUBES_GPG_AUTOACCEPT seconds)?"
     zenity --question --text "$msg_text" 2>/dev/null </dev/null >/dev/null || exit 1

--- a/qubes.Gpg.service
+++ b/qubes.Gpg.service
@@ -1,2 +1,16 @@
-notify-send "Keyring access from domain: $QREXEC_REMOTE_DOMAIN" --expire-time=1000
+#!/bin/sh
+
+if [ -z "$QUBES_GPG_AUTOACCEPT" ]; then
+    QUBES_GPG_AUTOACCEPT=300
+fi
+stat_file="/var/run/qubes-gpg-split/stat.$QREXEC_REMOTE_DOMAIN"
+stat_time=$(stat -c %Y "$stat_file" 2>/dev/null || echo 0)
+now=$(date +%s)
+if [ $(($stat_time + $QUBES_GPG_AUTOACCEPT)) -lt "$now" ]; then
+    msg_text="Do you allow VM '$QREXEC_REMOTE_DOMAIN' to access your GPG keys "
+    msg_text="$msg_text (now and for the following $QUBES_GPG_AUTOACCEPT seconds)?"
+    zenity --question --text "$msg_text" 2>/dev/null </dev/null >/dev/null || exit 1
+    touch "$stat_file"
+fi
+notify-send "Keyring access from domain: $QREXEC_REMOTE_DOMAIN" --expire-time=1000 </dev/null >/dev/null 2>/dev/null
 /usr/lib/qubes-gpg-split/gpg-server /usr/bin/gpg2 $QREXEC_REMOTE_DOMAIN

--- a/rpm_spec/gpg-split.spec.in
+++ b/rpm_spec/gpg-split.spec.in
@@ -78,7 +78,7 @@ rm -rf $RPM_BUILD_ROOT
 /usr/bin/qubes-gpg-client
 /usr/bin/qubes-gpg-client-wrapper
 /usr/bin/qubes-gpg-import-key
-%attr(0644,root,root) /etc/qubes-rpc/qubes.Gpg
+/etc/qubes-rpc/qubes.Gpg
 %attr(0644,root,root) /etc/qubes-rpc/qubes.GpgImportKey
 /etc/profile.d/qubes-gpg.sh
 %dir %attr(0777,root,root) /var/run/qubes-gpg-split


### PR DESCRIPTION
qubes.Gpg service may be called before X server is started in the VM.
This will result in a failure and be treated as user rejecting the
access.

Fix this by calling qubes.WaitForSession before asking for confirmation.

Fixes QubesOS/qubes-issues#4528