### PR TITLE
remove duplicated option in manpage

### DIFF
--- a/doc/qubes-gpg-client.rst
+++ b/doc/qubes-gpg-client.rst
@@ -94,8 +94,6 @@ found about their functionality in the gpg2 manpage.
 
 --fixed-list-mode
 
---fixed-list-mode
-
 --force-mdc
 
 --force-v3-sigs


### PR DESCRIPTION
`--fixed-list-mode` in the `qubes-gpg-client` manpage is duplicated. This change fixes the typo.