### PR TITLE
add ignore for --disable-dirmngr option

### DIFF
--- a/gpg-client-wrapper
+++ b/gpg-client-wrapper
@@ -64,6 +64,13 @@ while [[ $1 ]]; do
             --keyserver-options)
                 shift 2
                 ;;
+            # Using dirmngr in an offline GPG VM makes no sense, however
+            # qubes-gpg-client does not recognize the command line option
+            # --disable-dirmngr so to avoid an error message we ignore
+            # this option.
+            --disable-dirmngr)
+                shift
+                ;;
             # --photo-viewer shouldn't be passed to the backend as it allow
             # arbitrary command execution
             --photo-viewer)


### PR DESCRIPTION
The qubes-gpg-client does not recognize the option --disable-dirmngr and thus
gives the error message "unrecognized option '--disable-dirmngr'".
In some mail clients there is little control over which arguments are passed to
gpg, in which case using split-gpg won't work due to this error message.