### PR TITLE
tests: master key sign-only + subkey

### DIFF
--- a/tests/splitgpg/tests.py
+++ b/tests/splitgpg/tests.py
@@ -46,7 +46,10 @@ class SplitGPGBase(qubes.tests.extra.ExtraTestCase):
         p.communicate('''
 Key-Type: RSA
 Key-Length: 1024
-Key-Usage: sign encrypt
+Key-Usage: sign
+Subkey-Type: RSA
+Subkey-Length: 1024
+Subkey-Usage: encrypt
 Name-Real: Qubes test
 Name-Email: user@localhost
 Expire-Date: 0


### PR DESCRIPTION
Version 78.10.2 [started supporting offline master keys](https://bugzilla.mozilla.org/show_bug.cgi?id=1654893). This change
broke the configuration where the master key is offline and has no
subkeys. This is a non-default PGP key generation and hence has
little change users are in this situation.

The commit generate a master key with signing-capabilities only and a subkey for encryption

Fixes QubesOS/qubes-issues/issues/6712