### PR TITLE
tests: generate w/ subkeys in remaining tests

### DIFF
--- a/tests/splitgpg/tests.py
+++ b/tests/splitgpg/tests.py
@@ -173,7 +173,10 @@ class TC_00_Direct(SplitGPGBase):
         p.communicate('''
 Key-Type: RSA
 Key-Length: 1024
-Key-Usage: sign encrypt
+Key-Usage: sign
+Subkey-Type: RSA
+Subkey-Length: 1024
+Subkey-Usage: encrypt
 Name-Real: Qubes test2
 Name-Email: user2@localhost
 Expire-Date: 0
@@ -209,7 +212,10 @@ Expire-Date: 0
         p.communicate('''
 Key-Type: RSA
 Key-Length: 1024
-Key-Usage: sign encrypt
+Key-Usage: sign
+Subkey-Type: RSA
+Subkey-Length: 1024
+Subkey-Usage: encrypt
 Name-Real: Qubes test2
 Name-Email: user2@localhost
 Expire-Date: 0

--- a/tests/splitgpg/tests.py
+++ b/tests/splitgpg/tests.py
@@ -46,7 +46,10 @@ class SplitGPGBase(qubes.tests.extra.ExtraTestCase):
         p.communicate('''
 Key-Type: RSA
 Key-Length: 1024
-Key-Usage: sign encrypt
+Key-Usage: sign
+Subkey-Type: RSA
+Subkey-Length: 1024
+Subkey-Usage: encrypt
 Name-Real: Qubes test
 Name-Email: user@localhost
 Expire-Date: 0


### PR DESCRIPTION
Make remaining tests generate subkeys as well. This way all tests generate keys the same way (closer to the default attended key  generation - `gpg --gen-key`)