### PR TITLE
test: fix missed clicks on "open file" dialogue

### DIFF
--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -525,6 +525,9 @@ def configure_openpgp_account(tb):
                          roleName='menu item')).doActionNamed('click')
     file_chooser = tb.findChild(GenericPredicate(name='Import OpenPGP Key File',
                                                  roleName='file chooser'))
+    # wait for dialog to completely initialize, otherwise it may try to click
+    # on "Home" before it is active.
+    time.sleep(1)
     click(*file_chooser.childNamed('Home').position)
     click(*file_chooser.childNamed('pub.asc').position)
     file_chooser.childNamed('Open').doActionNamed('click')


### PR DESCRIPTION
Tests like
https://openqa.qubes-os.org/tests/19954#step/TC_10_Thunderbird_fedora-34-xfce/1
were being unable to select the public key "pub.asc" from the open
file dialogue. Giving it some time, solves the issue.

fixes QubesOS/qubes-issues/issues/6812