### PR TITLE
Remove enigmail test code

### DIFF
--- a/tests/splitgpg/tests.py
+++ b/tests/splitgpg/tests.py
@@ -340,9 +340,6 @@ class TC_10_Thunderbird(SplitGPGBase):
         #         != 0:
         #     self.skipTest('dogtail >= 0.9.0 testing framework not installed')
 
-        # enigmail checks for ~/.gnupg dir...
-        self.frontend.run('mkdir -p .gnupg', wait=True)
-
         p = self.frontend.run('gsettings set org.gnome.desktop.interface '
                               'toolkit-accessibility true', wait=True)
         assert p == 0, 'Failed to enable accessibility toolkit'
@@ -442,9 +439,6 @@ class TC_20_Evolution(SplitGPGBase):
         #         'sys.exit(dogtail.__version__ < "0.9.0")\'', wait=True) \
         #         != 0:
         #     self.skipTest('dogtail >= 0.9.0 testing framework not installed')
-
-        # enigmail checks for ~/.gnupg dir...
-        self.frontend.run('mkdir -p .gnupg', wait=True)
 
         p = self.frontend.run('gsettings set org.gnome.desktop.interface '
                               'toolkit-accessibility true', wait=True)

--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -65,15 +65,6 @@ def run(cmd):
         [cmd], stdout=null, stdin=null, stderr=null, env=env)
 
 
-def get_version(cmd):
-    try:
-        res = subprocess.check_output([cmd, '--version'])
-        version = res.decode('utf-8').replace('Thunderbird ', '').split('.')[0]
-    except (subprocess.SubprocessError, IndexError):
-        raise Exception('Cannot determine version')
-    return int(version)
-
-
 def get_key_fpr():
     try:
         cmd = '/usr/bin/qubes-gpg-client-wrapper -K --with-colons'
@@ -105,7 +96,7 @@ def get_app():
     return tb
 
 
-def skip_autoconf(tb, version):
+def skip_autoconf(tb):
     # Icedove/Thunderbird 60+ flavor
     try:
         welcome = tb.childNamed('Mail Account Setup'
@@ -114,14 +105,6 @@ def skip_autoconf(tb, version):
         welcome.button('Cancel').doActionNamed('press')
     except tree.SearchError:
         pass
-    if version < 78:
-        # if enigmail is already installed
-        try:
-            tb.dialog('Enigmail Setup Wizard').button('Cancel'). \
-                doActionNamed('press')
-            tb.dialog('Enigmail Alert').button('Close').doActionNamed('press')
-        except tree.SearchError:
-            pass
     # Accept Qubes Attachment
     try:
         qubes_att = tb.child(name='Qubes Attachments added', roleName='label')
@@ -138,15 +121,6 @@ def skip_autoconf(tb, version):
     config.searchCutoffCount = defaultCutoffCount
 
 
-def skip_system_integration(tb):
-    try:
-        integration = tb.childNamed('System Integration')
-        integration.childNamed('Always perform .*').doActionNamed('uncheck')
-        integration.button('Skip Integration').doActionNamed('press')
-    except tree.SearchError:
-        pass
-
-
 def open_account_setup(tb):
     edit = tb.menu('Edit')
     edit.doActionNamed('click')
@@ -159,7 +133,7 @@ class TBEntry(GenericPredicate):
         super(TBEntry, self).__init__(name=name, roleName='entry')
 
 
-def add_local_account(tb, version):
+def add_local_account(tb):
     open_account_setup(tb)
     settings = tb.findChild(orPredicate(
         GenericPredicate(name='Account Settings.*', roleName='frame'),
@@ -185,13 +159,10 @@ def add_local_account(tb, version):
 
     # set outgoing server
     settings.childNamed('Outgoing Server (SMTP)').doActionNamed('activate')
-    if version >= 78:
-        smtp_settings = settings.findChild(
-            GenericPredicate(name='Outgoing Server (SMTP) Settings',
-                             roleName='document web'))
-        smtp_settings.button('Add.*').doActionNamed('press')
-    else:
-        settings.button('Add.*').doActionNamed('press')
+    smtp_settings = settings.findChild(
+        GenericPredicate(name='Outgoing Server (SMTP) Settings',
+                            roleName='document web'))
+    smtp_settings.button('Add.*').doActionNamed('press')
     add_server = tb.findChild(orPredicate(
         GenericPredicate(name='SMTP Server.*', roleName='frame'),
         GenericPredicate(name='SMTP Server', roleName='dialog'),
@@ -199,208 +170,15 @@ def add_local_account(tb, version):
     add_server.findChild(TBEntry('Description:')).text = 'localhost'
     add_server.findChild(TBEntry('Server Name:')).text = 'localhost'
     config.searchCutoffCount = 5
-    if version >= 78:
-        port = tb.findChild(
-            GenericPredicate(name='Port:', roleName='spin button'))
-    else:
-        port = add_server.findChild(TBEntry('Port:'))
+    port = tb.findChild(
+        GenericPredicate(name='Port:', roleName='spin button'))
     port.text = '8025'
     add_server.menuItem('No authentication').doActionNamed('click')
     add_server.button('OK').doActionNamed('press')
-    if version >= 78:
-        file = settings.menu('File')
-        file.doActionNamed('click')
-        file.child('Close').doActionNamed('click')
-    else:
-        try:
-            settings.button('OK').doActionNamed('press')
-        except tree.SearchError:
-            pass
-    config.searchCutoffCount = defaultCutoffCount
-
-
-def install_enigmail_web_search(tb, search):
-    """Handle new addons manager search result which is just embedded
-    addons.thunderbird.net website"""
-
-    # search term
-    search.children[0].text = 'enigmail'
-    # search button
-    search.children[1].doActionNamed('press')
-    results = tb.child(
-        name='enigmail :: Search :: Add-ons for Thunderbird',
-        roleName='document web')
-
-    # # navigation on the website is fragile and ugly, but what we can do, the
-    # # old addons manager is gone
-    # # find "Enigmail" link, then navigate through the table to a column to its
-    # # right with "Add to Thunderbird link"
-    # enigmail_link = results.findChild(GenericPredicate(name='Enigmail', roleName='link'))
-    # # Enigmail (link) -> Enigmail FEATURED (heading) -> '' (section) -> '' (section)
-    # # TODO: how to find next sibling? right now it relies on first result being the right one
-    # time.sleep(3)
-    # install_link = enigmail_link.parent.parent.parent. \
-    #     children[1].child(name='Add to Thunderbird', roleName='link')
-
-    # TODO: right now it relies on first result being the right one
-    install_link = results.findChild(GenericPredicate(name='Add to Thunderbird', roleName='link'))
-    install_link.doActionNamed('jump')
-    config.searchCutoffCount = 20
-    install_dialog = tb.findChild(orPredicate(
-        GenericPredicate(name='Software Installation', roleName='frame'),
-        GenericPredicate(name='Software Installation', roleName='dialog'),
-        GenericPredicate(name='Add Enigmail?', roleName='label'),
-    ))
-    # now confirmation dialog, it needs to have focus for 3 sec until "Install"
-    # button will be active
-    time.sleep(3)
-    if install_dialog.roleName == 'label':
-        install_dialog.parent.button('Add').doActionNamed('press')
-        installed = tb.child(name='Enigmail has been added.*', roleName='label')
-        time.sleep(1)
-        installed.parent.button('OK').doActionNamed('press')
-    else:
-        install_dialog.button('Install Now').doActionNamed('press')
-    config.searchCutoffCount = defaultCutoffCount
-
-
-def install_enigmail_builtin(tb, search):
-    """Handle old, built-in search results browser"""
-    # search term
-    search.children[0].text = 'enigmail'
-    # search button
-    search.children[1].doActionNamed('press')
-
-    addons = tb.child(name='Add-ons Manager', roleName='embedded')
-    enigmail = addons.child(name='Enigmail .*More.*', roleName='list item')
-    enigmail.button('Install').doActionNamed('press')
-    config.searchCutoffCount = 5
-    try:
-        addons.button('Restart now').doActionNamed('press')
-    except tree.SearchError:
-        # no restart needed for this version
-        addons_tab = tb.child(name='Add-ons Manager', roleName='page tab')
-        addons_tab.button('').doActionNamed('press')
-        return
-    finally:
-        config.searchCutoffCount = defaultCutoffCount
-
-    tree.doDelay(5)
-    tb = get_app()
-    skip_system_integration(tb)
-
-    tb.dialog('Enigmail Setup Wizard').button('Cancel').doActionNamed('press')
-    tb.dialog('Enigmail Alert').button('Close').doActionNamed('press')
-    file = tb.menu('File')
+    file = settings.menu('File')
     file.doActionNamed('click')
     file.child('Close').doActionNamed('click')
-
-
-def install_enigmail(tb):
-    tools = tb.menu('Tools')
-    tools.doActionNamed('click')
-    tools.menuItem('Add-ons').doActionNamed('click')
-    addons = tb.child(name='Add-ons Manager', roleName='embedded')
-    # check if already installed
-    addons.child(name='Extensions', roleName='list item'). \
-        doActionNamed('')
-    time.sleep(1)
-    config.searchCutoffCount = 1
-    try:
-        addons_list = \
-            addons.findChildren(GenericPredicate(name='', roleName='list box'),
-                                recursive=False)[1]
-        addons_list.childNamed('Enigmail.*')
-    except tree.SearchError:
-        pass
-    else:
-        # already installed
-        return
-    finally:
-        config.searchCutoffCount = defaultCutoffCount
-    search = addons.child(
-        name='Search all add-ons|Search on addons.thunderbird.net|Find more extensions',
-        roleName='section')
-    if 'addons.thunderbird.net' in search.name or 'Find more' in search.name:
-        install_enigmail_web_search(tb, search)
-    else:
-        install_enigmail_builtin(tb, search)
-    file = tb.menu('File')
-    file.doActionNamed('click')
-    file.child('Close').doActionNamed('click')
-
-    # in case where addons tab is still here
-    try:
-        addons = tb.child(name='Add-ons Manager', roleName='embedded')
-        if addons:
-            file = tb.menu('File')
-            file.doActionNamed('click')
-            file.child('Close').doActionNamed('click')
-    except tree.SearchError:
-        pass
-
-
-def configure_enigmail_global(tb):
-    # disable p≡p Junior before creating an account, see
-    # https://sourceforge.net/p/enigmail/bugs/904/
-    menu = tb.menu('Edit')
-    menu.doActionNamed('click')
-    menu.menuItem('Preferences').doActionNamed('click')
-    config.searchCutoffCount = 20
-    preferences = tb.findChild(orPredicate(
-        GenericPredicate(name='Thunderbird Preferences.*', roleName='frame'),
-        GenericPredicate(name='Thunderbird Preferences', roleName='dialog'),
-    ))
-    try:
-        preferences.child(name='Privacy', roleName='radio button'). \
-            doActionNamed('select')
-    except tree.SearchError:
-        preferences.child(name='Privacy', roleName='list item'). \
-            doActionNamed('')
     config.searchCutoffCount = defaultCutoffCount
-    preferences.child(
-        name='Force using S/MIME and Enigmail',
-        roleName='radio button'). \
-        doActionNamed('select')
-    config.searchCutoffCount = 5
-    try:
-        tb.child(name='Thunderbird Preferences', roleName='page tab'). \
-            button('').doActionNamed('press')
-    except tree.SearchError:
-        preferences.button('Close').doActionNamed('press')
-    config.searchCutoffCount = defaultCutoffCount
-
-    menu = tb.menu('Enigmail.*')
-    menu.doActionNamed('click')
-    menu.menuItem('Preferences').doActionNamed('click')
-
-    enigmail_prefs = tb.dialog('Enigmail Preferences')
-    # wait for dialog to really initialize, otherwise it may load defaults
-    # over just set values
-    time.sleep(1)
-    try:
-        enigmail_prefs.child(name='Override with',
-                             roleName='check box').doActionNamed('check')
-        enigmail_prefs.child(
-            name='Override with',
-            roleName='section').children[0].text = \
-            '/usr/bin/qubes-gpg-client-wrapper'
-    except tree.ActionNotSupported:
-        pass
-
-    enigmail_prefs.button('OK').doActionNamed('press')
-    config.searchCutoffCount = 5
-    try:
-        agent_alert = tb.dialog('Enigmail Alert')
-        if 'Cannot connect to gpg-agent' in agent_alert.description:
-            agent_alert.childNamed('Do not show.*').doActionNamed('check')
-            agent_alert.button('OK').doActionNamed('press')
-        else:
-            raise Exception('Unknown alert: {}'.format(agent_alert.description))
-    except tree.SearchError:
-        pass
-    finally:
-        config.searchCutoffCount = defaultCutoffCount
 
 
 def configure_openpgp_global(tb):
@@ -458,7 +236,7 @@ def show_menu_bar(tb):
     config.searchCutoffCount = defaultCutoffCount
 
 
-def disable_html(tb, version):
+def disable_html(tb):
     open_account_setup(tb)
     settings = tb.findChild(orPredicate(
         GenericPredicate(name='Account Settings.*', roleName='frame'),
@@ -472,29 +250,9 @@ def disable_html(tb, version):
             'uncheck')
     except tree.ActionNotSupported:
         pass
-    if version >= 78:
-        file = settings.menu('File')
-        file.doActionNamed('click')
-        file.child('Close').doActionNamed('click')
-    else:
-        try:
-            settings.button('OK').doActionNamed('press')
-        except tree.SearchError:
-            pass
-
-
-def configure_enigmail_account(tb):
-    open_account_setup(tb)
-    settings = tb.dialog('Account Settings')
-    # assume only one account...
-    settings.childNamed('OpenPGP Security').doActionNamed('activate')
-    # enigmail will do a couple of calls to gpg, give it some time
-    time.sleep(4)
-    try:
-        settings.childNamed('Enable OpenPGP.*').doActionNamed('check')
-    except tree.ActionNotSupported:
-        pass
-    settings.button('OK').doActionNamed('press')
+    file = settings.menu('File')
+    file.doActionNamed('click')
+    file.child('Close').doActionNamed('click')
 
 
 def configure_openpgp_account(tb):
@@ -576,24 +334,13 @@ def attach(tb, compose_window, path):
     # select_file.button('Open').doActionNamed('click')
 
 
-def send_email(tb, version=0, sign=False, encrypt=False, inline=False,
-               attachment=None):
+def send_email(tb, sign=False, encrypt=False, inline=False, attachment=None):
     config.searchCutoffCount = 20
     write = tb.button('Write')
     config.searchCutoffCount = defaultCutoffCount
     write.doActionNamed('press')
-    if version < 78:
-        try:
-            # write.menuItem('Message').doActionNamed('click')
-            tb.button('Write').menuItem('Message').doActionNamed('click')
-        except tree.SearchError:
-            # no write what submenu
-            pass
     compose = tb.child(name='Write: .*', roleName='frame')
-    if version < 78:
-        to_entry = compose.findChild(GenericPredicate(name='To:', roleName='autocomplete')).children[0]
-    else:
-        to_entry = compose.findChild(TBEntry(name='To'))
+    to_entry = compose.findChild(TBEntry(name='To'))
     to_entry.text = 'user@localhost'
     # lets thunderbird settle down on default values (after filling recipients)
     time.sleep(1)
@@ -611,56 +358,18 @@ def send_email(tb, version=0, sign=False, encrypt=False, inline=False,
     except tree.SearchError:
         compose.child(
             roleName='document frame').text = 'This is test message'
-    if version >= 78:
-        security = compose.findChild(
-            GenericPredicate(name='Security', roleName='push button'))
-        security.doActionNamed('press')
-        sign_button = security.childNamed('Digitally Sign This Message')
-        encrypt_button = security.childNamed('Require Encryption')
-        if sign_button.checked != sign:
-            sign_button.doActionNamed('click')
-        if encrypt_button.checked != encrypt:
-            encrypt_button.doActionNamed('click')
-    else:
-        try:
-            sign_button = compose.button('Sign Message')
-            encrypt_button = compose.button('Encrypt Message')
-        except tree.SearchError:
-            # old thunderbird/enigmail
-            compose.button('Enigmail Encryption Info').doActionNamed('press')
-            sign_encrypt = tb.dialog('Enigmail Encryption & Signing Settings')
-            encrypt_checkbox = sign_encrypt.childNamed('Encrypt Message')
-            if encrypt_checkbox.checked != encrypt:
-                encrypt_checkbox.doActionNamed(
-                    encrypt_checkbox.actions.keys()[0])
-            sign_checkbox = sign_encrypt.childNamed('Sign Message')
-            if sign_checkbox.checked != sign:
-                sign_checkbox.doActionNamed(sign_checkbox.actions.keys()[0])
-            if inline:
-                sign_encrypt.childNamed('Use Inline PGP').doActionNamed(
-                    'select')
-            else:
-                sign_encrypt.childNamed('Use PGP/MIME').doActionNamed('select')
-            sign_encrypt.button('OK').doActionNamed('press')
-        else:
-            if ('ON' in sign_button.description) != sign:
-                sign_button.doActionNamed('press')
-            if ('ON' in encrypt_button.description) != encrypt:
-                encrypt_button.doActionNamed('press')
-            if inline:
-                enigmail_menu = compose.menu('Enigmail')
-                enigmail_menu.doActionNamed('click')
-                enigmail_menu.menuItem('Protocol: Inline PGP').doActionNamed(
-                    'click')
-
+    security = compose.findChild(
+        GenericPredicate(name='Security', roleName='push button'))
+    security.doActionNamed('press')
+    sign_button = security.childNamed('Digitally Sign This Message')
+    encrypt_button = security.childNamed('Require Encryption')
+    if sign_button.checked != sign:
+        sign_button.doActionNamed('click')
+    if encrypt_button.checked != encrypt:
+        encrypt_button.doActionNamed('click')
     if attachment:
         attach(tb, compose, attachment)
     compose.button('Send').doActionNamed('press')
-    try:
-        if inline and attachment:
-            tb.dialog('Enigmail Prompt').button('OK').doActionNamed('press')
-    except tree.SearchError:
-        pass
     config.searchCutoffCount = 5
     try:
         if encrypt:
@@ -672,8 +381,7 @@ def send_email(tb, version=0, sign=False, encrypt=False, inline=False,
         config.searchCutoffCount = defaultCutoffCount
 
 
-def receive_message(tb, version=0, signed=False, encrypted=False,
-                    attachment=None):
+def receive_message(tb, signed=False, encrypted=False, attachment=None):
     tb.child(name='user@localhost',
              roleName='table row').doActionNamed('activate')
     tb.button('Get Messages').doActionNamed('press')
@@ -716,45 +424,36 @@ def receive_message(tb, version=0, signed=False, encrypted=False,
     #        msg_body = msg.text
     config.searchCutoffCount = 5
     try:
-        if version >= 78:
-            if signed or encrypted:
-                # 'Message Security' can be either full dialog or a popup -
-                # depending on TB version
-                popup = False
+        if signed or encrypted:
+            # 'Message Security' can be either full dialog or a popup -
+            # depending on TB version
+            popup = False
+            tb.findChild(GenericPredicate(
+                name='View', roleName='menu')).doActionNamed('click')
+            try:
+                tb.findChild(GenericPredicate(
+                    name='Message Security Info',
+                    roleName='menu item')).doActionNamed('click')
+                message_security = tb.child('Message Security')
+            except tree.SearchError:
+                # on debian there is no menu entry, but OpenPGP button
+                # first close view menu
                 tb.findChild(GenericPredicate(
                     name='View', roleName='menu')).doActionNamed('click')
-                try:
-                    tb.findChild(GenericPredicate(
-                        name='Message Security Info',
-                        roleName='menu item')).doActionNamed('click')
-                    message_security = tb.child('Message Security')
-                except tree.SearchError:
-                    # on debian there is no menu entry, but OpenPGP button
-                    # first close view menu
-                    tb.findChild(GenericPredicate(
-                        name='View', roleName='menu')).doActionNamed('click')
-                    tb.button('OpenPGP').doActionNamed('press')
-                    # 'Message Security - OpenPGP' is an internal label,
-                    # nested 2 levels into the popup
-                    message_security = tb.child('Message Security - OpenPGP')
-                    message_security = message_security.parent.parent
-                    popup = True
-                if signed:
-                    message_security.child('Good Digital Signature')
-                if encrypted:
-                    message_security.child('Message Is Encrypted')
-                if not popup:
-                    message_security.button('OK').doActionNamed('press')
-                else:
-                    message_security.parent.click()
-        else:
-            details = tb.button('Details')
-            enigmail_status = details.parent.children[details.indexInParent - 1]
-            print('Enigmail status: {}'.format(enigmail_status.text))
+                tb.button('OpenPGP').doActionNamed('press')
+                # 'Message Security - OpenPGP' is an internal label,
+                # nested 2 levels into the popup
+                message_security = tb.child('Message Security - OpenPGP')
+                message_security = message_security.parent.parent
+                popup = True
             if signed:
-                assert 'Good signature from' in enigmail_status.text
+                message_security.child('Good Digital Signature')
             if encrypted:
-                assert 'Decrypted message' in enigmail_status.text
+                message_security.child('Message Is Encrypted')
+            if not popup:
+                message_security.button('OK').doActionNamed('press')
+            else:
+                message_security.parent.click()
     except tree.SearchError:
         if signed or encrypted:
             raise
@@ -783,18 +482,12 @@ def receive_message(tb, version=0, signed=False, encrypted=False,
                 'click')
         # for some reasons some Thunderbird versions do not expose 'Attach File'
         # dialog through accessibility API, use xdotool instead
-        if version >= 78:
-            save_as = tb.findChild(
-                GenericPredicate(name='Save All Attachments',
-                                 roleName='file chooser'))
-            click(*save_as.childNamed('Home').position)
-            click(*save_as.childNamed('Desktop').position)
-            save_as.childNamed('Open').doActionNamed('click')
-        else:
-            subprocess.check_call(
-                ['xdotool', 'search', '--name', 'Save Attachment',
-                 'key', '--window', '0', '--delay', '30ms', 'ctrl+l', 'Home',
-                 'type', '~/Desktop/\r'])
+        save_as = tb.findChild(
+            GenericPredicate(name='Save All Attachments',
+                                roleName='file chooser'))
+        click(*save_as.childNamed('Home').position)
+        click(*save_as.childNamed('Desktop').position)
+        save_as.childNamed('Open').doActionNamed('click')
         # save_as = tb.dialog('Save .*Attachment.*')
         # places = save_as.child(roleName='table',
         #    name='Places')
@@ -867,31 +560,21 @@ def main():
     # log only to stdout since logging to file have broken unicode support
     config.logDebugToFile = False
 
-    # get Thunderbird version
-    version = get_version(args.tbname)
-
     proc = run(args.tbname)
     if args.command == 'setup':
         tb = get_app()
-        skip_autoconf(tb, version)
+        skip_autoconf(tb)
         show_menu_bar(tb)
-        if version < 78:
-            install_enigmail(tb)
-            configure_enigmail_global(tb)
-        else:
-            configure_openpgp_global(tb)
+        configure_openpgp_global(tb)
         quit_tb(tb)
         subprocess.call(['pkill', 'pep-json-server'])
         proc.wait()
         proc = run(args.tbname)
         tb = get_app()
-        skip_autoconf(tb, version)
-        add_local_account(tb, version)
-        if version < 78:
-            configure_enigmail_account(tb)
-        else:
-            configure_openpgp_account(tb)
-        disable_html(tb, version)
+        skip_autoconf(tb)
+        add_local_account(tb)
+        configure_openpgp_account(tb)
+        disable_html(tb)
         quit_tb(tb)
     if args.command == 'send_receive':
         tb = get_app()
@@ -901,12 +584,11 @@ def main():
                 f.write('This is test attachment content')
         else:
             attachment = None
-        send_email(tb, version=version, sign=args.signed,
-                   encrypt=args.encrypted, inline=args.inline,
-                   attachment=attachment)
+        send_email(tb, sign=args.signed, encrypt=args.encrypted,
+                   inline=args.inline, attachment=attachment)
         time.sleep(5)
-        receive_message(tb, version=version, signed=args.signed,
-                        encrypted=args.encrypted, attachment=attachment)
+        receive_message(tb, signed=args.signed, encrypted=args.encrypted,
+                        attachment=attachment)
         quit_tb(tb)
 
 


### PR DESCRIPTION
Enigmail was the previous way of using GPG with thunderbird. Now that's built-in from Thunderbird 78+. The code had branches to support before and after that change. But now that all default templates ship a version newer than 78, the enigmail support in code is no longer needed. This PR remove that, simplifying the Thunderbird test code.