### PR TITLE
Tests splitgpg setup: retry if failed

### DIFF
--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -183,6 +183,7 @@ class TBEntry(GenericPredicate):
         super(TBEntry, self).__init__(name=name, roleName='entry')
 
 
+@retry_if_failed(max_tries=3)
 def add_local_account(tb):
     open_account_setup(tb)
     settings = tb.app.findChild(orPredicate(
@@ -203,9 +204,12 @@ def add_local_account(tb):
     # outgoing server
     wizard.button('Next').doActionNamed('press')
     # account name
-    wizard.button('Next').doActionNamed('press')
-    # summary
-    wizard.button('Finish').doActionNamed('press')
+    if wizard.button('Next').sensitive:
+        wizard.button('Next').doActionNamed('press')
+        wizard.button('Finish').doActionNamed('press')
+    else:
+        # button disabled => account already created in previous try
+        wizard.button('Cancel').doActionNamed('press')
 
     # set outgoing server
     settings.childNamed('Outgoing Server (SMTP)').doActionNamed('activate')

--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -30,6 +30,7 @@ from dogtail.rawinput import click, doubleClick
 import subprocess
 import os
 import time
+import functools
 
 subject = 'Test message {}'.format(os.getpid())
 
@@ -106,7 +107,9 @@ def retry_if_failed(max_tries):
     consecutively or multiple partial times it leads to the same result as if
     ran only once)
     """
-    def retry_if_failed_decorator(func):
+
+    def decorator(func):
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             tb = args[0]
 
@@ -123,7 +126,7 @@ def retry_if_failed(max_tries):
                         tb.kill()
                         tb.start()
         return wrapper
-    return retry_if_failed_decorator
+    return decorator
 
 
 def get_key_fpr():


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#6817.

During the Thunderbird tests `setUp()` many times it fails randomly (see QubesOS/qubes-issues#6817). This retries particularly problematic setup steps when they fail. It's implemented via a decorator `retry_if_failed()`.

If other setups become problematic all one has to do is to make the setup step generally idempotent (see docstring of `retry_if_failed`) and add the decorator.