### PR TITLE
tests: increase search attempts for thunderbird start

### DIFF
--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -75,7 +75,7 @@ class Thunderbird:
         self.app = self._get_app()
 
     def _get_app(self):
-        config.searchCutoffCount = 50
+        config.searchCutoffCount = 70
         tb = tree.root.application('Thunderbird|Icedove')
         time.sleep(5)
         # now get it again to make sure we have the main window,


### PR DESCRIPTION
Fedora-34-xfce was taking quite a bit longer. See:
https://openqa.qubes-os.org/tests/21405#step/TC_10_Thunderbird_fedora-34-xfce/1

![fail-splitgpg-select-thunderbird](https://user-images.githubusercontent.com/47065258/136011970-395d304f-edb6-45fc-82ab-1c1fc4c4f8c7.png)

spiritual successor to e304e584 as a testament to the ever increasing complexity of software (beyond Qubes)

closes https://github.com/QubesOS/qubes-issues/issues/7151