### PR TITLE
tests: earlier detection of failed message sending

### DIFF
--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -334,8 +334,15 @@ def send_email(tb, sign=False, encrypt=False, inline=False, attachment=None):
                 button('Protect subject').doActionNamed('press')
     except tree.SearchError:
         pass
+    # if there is a dialog window, then there must have been some issue sending
+    try:
+        tb.app.dialog('.*')
+        raise Exception("Failed to send message")
+    except tree.SearchError:
+        pass
     finally:
         config.searchCutoffCount = defaultCutoffCount
+
 
 
 def receive_message(tb, signed=False, encrypted=False, attachment=None):

--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -336,8 +336,13 @@ def send_email(tb, sign=False, encrypt=False, inline=False, attachment=None):
         pass
     # if there is a dialog window, then there must have been some issue sending
     try:
-        tb.app.dialog('.*')
-        raise Exception("Failed to send message")
+        dialog = tb.app.dialog('.*')
+        try:
+            dialog_text = dialog.child(roleName='label').text
+            raise Exception("Failed to send message with error '{}'"\
+                .format(dialog_text))
+        except tree.SearchError:
+            raise Exception("Failed to send message")
     except tree.SearchError:
         pass
     finally:

--- a/tests/test_thunderbird.py
+++ b/tests/test_thunderbird.py
@@ -334,6 +334,8 @@ def send_email(tb, sign=False, encrypt=False, inline=False, attachment=None):
                 button('Protect subject').doActionNamed('press')
     except tree.SearchError:
         pass
+    finally:
+        config.searchCutoffCount = defaultCutoffCount
 
     # Fail if something like a dialog box prevented the compose window to be
     # closed. Means no email was actually sent.


### PR DESCRIPTION
In Thunderbird when for various reasons would fail to send a message the program would continue with the sending message part and only fail then.

This makes makes the error message be detected at a stage at least closer to where the issue might have happened.

One example is this one: https://openqa.qubes-os.org/tests/22143#step/TC_10_Thunderbird_whonix-ws-16/2. Here the error shows as having something do with not finding the email received, but it was never sent in the first place because there was an error while sending it.