### PR TITLE
Fix off-by-one in fd path replacement

### DIFF
--- a/src/gpg-common.c
+++ b/src/gpg-common.c
@@ -99,7 +99,7 @@ void handle_opt_verify(char *untrusted_sig_path, int *list, int *list_count, int
          * space is critical here (for thunderbird it must fit in place of "/tmp/data.sig") */
         untrusted_sig_path_size = strlen(untrusted_sig_path)+1;
         written = snprintf(untrusted_sig_path, untrusted_sig_path_size, "/dev/fd/%d", cur_fd);
-        if (written < 0 || written > untrusted_sig_path_size) {
+        if (written < 0 || written + 1 > untrusted_sig_path_size) {
             fprintf(stderr, "Failed to fit /dev/fd/%d in place of signature path\n", cur_fd);
             exit(1);
         }

--- a/src/gpg-common.c
+++ b/src/gpg-common.c
@@ -58,8 +58,8 @@ void handle_opt_verify(char *untrusted_sig_path, int *list, int *list_count, int
     int i;
     char *sig_path;
     int cur_fd, untrusted_cur_fd;
-    int untrusted_sig_path_size;
-    int written;
+    int untrusted_sig_path_len;
+    int fd_path_len;
 
     if (*list_count >= MAX_FDS - 1) {
         fprintf(stderr, "Too many FDs used\n");
@@ -97,9 +97,9 @@ void handle_opt_verify(char *untrusted_sig_path, int *list, int *list_count, int
         /* HACK: override original file path with FD virtual path, hope it will
          * fit; use /dev/fd instead of /proc/self/fd because is is shorter and
          * space is critical here (for thunderbird it must fit in place of "/tmp/data.sig") */
-        untrusted_sig_path_size = strlen(untrusted_sig_path)+1;
-        written = snprintf(untrusted_sig_path, untrusted_sig_path_size, "/dev/fd/%d", cur_fd);
-        if (written < 0 || written + 1 > untrusted_sig_path_size) {
+        untrusted_sig_path_len = strlen(untrusted_sig_path);
+        fd_path_len = snprintf(untrusted_sig_path, untrusted_sig_path_len + 1, "/dev/fd/%d", cur_fd);
+        if (fd_path_len < 0 || fd_path_len > untrusted_sig_path_len) {
             fprintf(stderr, "Failed to fit /dev/fd/%d in place of signature path\n", cur_fd);
             exit(1);
         }


### PR DESCRIPTION
If I had a GPG signature file at /tmp/sig that I wanted to verify, `qubes-gpg-client --verify /tmp/sig` would fail with a very confusing error message:

    $ qubes-gpg-client --verify /tmp/sig
    --verify with filename allowed only on the client side
    EOF

This happened because of an off-by-one error — `untrusted_sig_path_size` includes the trailing null byte, while the return value of `snprintf` does not.  Therefore, qubes-gpg-client would think that the full file descriptor path had been written to `untrusted_sig_path`, even though the final byte would not have been, so `untrusted_sig_path` would have the value "/dev/fd/".  Alternatively, if a file descriptor greater than ten was being used, and the path to the signature file was one byte longer, the last decimal digit of the file descriptor number would be omitted — /dev/fd/1 instead of /dev/fd/10, for example.

So we need to add one to the return value of `snprintf` to take the trailing null byte into account before comparing it with `untrusted_sig_path_size`.  After making this change:

    $ qubes-gpg-client --verify /tmp/sig
    Failed to fit /dev/fd/3 in place of signature path

Which is the expected behaviour.

This was not a security issue, because the bug was client-side, and Split GPG design considers the client untrusted anyway.

In my first commit, I've fixed the bug, and in the second, I've refactored the code to make it more obvious what's going on, so a similar bug should be difficult to re-introduce.  The details of the refactoring are explained in the commit message of the second commit.

