### PR TITLE
tests: reduce whonix boot clock rand during testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ build:
 	$(MAKE) -C src
 	$(MAKE) -C doc manpages
 
-install-vm:
+install-vm-common:
 	install -d $(DESTDIR)$(LIBDIR)/qubes-gpg-split
 	install -t $(DESTDIR)$(LIBDIR)/qubes-gpg-split src/pipe-cat src/gpg-server
 	install -D src/gpg-client $(DESTDIR)/usr/bin/qubes-gpg-client
@@ -38,6 +38,11 @@ install-vm:
 	install -D qubes-gpg-split.tmpfiles $(DESTDIR)/etc/tmpfiles.d/qubes-gpg-split.conf
 	make -C tests install-vm
 	make -C doc install
+
+install-vm-deb: install-vm-common
+	make -C tests install-vm-deb
+
+install-vm-fedora: install-vm-common
 
 clean:
 	$(MAKE) -C src clean

--- a/debian/qubes-gpg-split-tests.install
+++ b/debian/qubes-gpg-split-tests.install
@@ -1,3 +1,4 @@
 usr/lib/qubes-gpg-split/test_smtpd.py
 usr/lib/qubes-gpg-split/test_thunderbird.py
 usr/lib/qubes-gpg-split/test_evolution.py
+lib/systemd/system/bootclockrandomization.service.d/override.conf

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ override_dh_auto_build:
 	make build
 
 override_dh_auto_install:
-	make install-vm
+	make install-vm-deb
 
 override_dh_install:
 	dh_install --fail-missing

--- a/rpm_spec/gpg-split.spec.in
+++ b/rpm_spec/gpg-split.spec.in
@@ -69,7 +69,7 @@ make build
 
 %install
 rm -rf $RPM_BUILD_ROOT
-make install-vm DESTDIR=$RPM_BUILD_ROOT
+make install-vm-fedora DESTDIR=$RPM_BUILD_ROOT
 
 %clean
 rm -rf $RPM_BUILD_ROOT

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -37,3 +37,9 @@ install-dom0-py3:
 install-vm:
 	install -d $(DESTDIR)/usr/lib/qubes-gpg-split
 	install test_*.py $(DESTDIR)/usr/lib/qubes-gpg-split/
+
+install-vm-deb: install-whonix-systemd-dropins
+
+install-whonix-systemd-dropins:
+	install -d $(DESTDIR)/lib/systemd/system/bootclockrandomization.service.d/
+	install whonix-clock-override.conf $(DESTDIR)/lib/systemd/system/bootclockrandomization.service.d/override.conf

--- a/tests/whonix-clock-override.conf
+++ b/tests/whonix-clock-override.conf
@@ -1,0 +1,7 @@
+# Reduces the bootclockrandomization to +/- 5 seconds
+#
+# Avoids having backwards time leaps which would mess up the tests making
+# them unstable.
+
+[Service]
+Environment="delay_plus_or_minus=5"


### PR DESCRIPTION
Overrides the whonix bootclockrandomization's delay from +/-180 seconds to +/- 5 seconds. Won't work until https://github.com/Whonix/bootclockrandomization/pull/2 makes its way into the repos.

## The problem
Whonix tests are now non-deterministically failing in two cases:

1.  [failing in splitgpg tests](https://openqa.qubes-os.org/tests/26118#step/TC_10_Thunderbird_whonix-ws-16/1). I've nailed this down to the fact that the backwards time leap is messing up the dovecot imap service we now use with thunderbird 91+ testing.

2. It also seems to be the root cause of [invalid GPG signatures](https://openqa.qubes-os.org/tests/26805#step/TC_10_Thunderbird_whonix-ws-16/3)
    
    ![error_signature](https://user-images.githubusercontent.com/47065258/147340527-30b7cb1e-af75-4dad-9e5c-cd64f9a8ab3d.png)


## Proposed solution
Having this var overridable by an env var so in the test suites we can reduce it to something like 5 seconds (already merged in https://github.com/Whonix/bootclockrandomization/pull/2)

## Testing
I've ran locally 140 tests with the delay set to 5 instead of 180 and this made it pass 140/140 splitgpg tests locally (quite impressive!), whereas before it used to fail more often.
