### PR TITLE
Translate `--detach-sig` to `--detach-sign`

### DIFF
--- a/gpg-client-wrapper
+++ b/gpg-client-wrapper
@@ -101,7 +101,7 @@ while (( $# )); do
             -q|--quiet|--yes)
                 shift
                 ;;
-            --detach)
+            --detach|--detach-sig)
                 options+=( --detach-sign )
                 shift
                 ;;


### PR DESCRIPTION
Some code apparently relies on `--detach-sig` working.

Reported-by: Frédéric Pierret <frederic.pierret@qubes-os.org>