### PR TITLE
Forcibly disable dirmngr

### DIFF
--- a/src/gpg-server.c
+++ b/src/gpg-server.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[])
     int i;
     int remote_argc, parsed_argc;
     char *(untrusted_remote_argv[COMMAND_MAX_LEN+1]);	// far too big should not harm
-    char *(remote_argv[COMMAND_MAX_LEN+2]);	// far too big should not harm
+    char *(remote_argv[COMMAND_MAX_LEN+3]);	// far too big should not harm
     int input_fds[MAX_FDS], output_fds[MAX_FDS];
     int input_fds_count, output_fds_count;
 
@@ -71,14 +71,17 @@ int main(int argc, char *argv[])
             exit(1);
         }
     }
-    memcpy(remote_argv + 2, untrusted_remote_argv + 1,
+
+    memcpy(remote_argv + 3, untrusted_remote_argv + 1,
            sizeof(untrusted_remote_argv) - sizeof(untrusted_remote_argv[0]));
     /* now options are verified and we get here only when all are allowed */
     remote_argv[0] = argv[1];
     // provide a better error message than "inappropriate ioctl for device"
     remote_argv[1] = "--no-tty";
+    // disable use of dirmngr, which makes no sense in a backend qube
+    remote_argv[2] = "--disable-dirmngr";
     // Add NULL terminator to argv list
-    remote_argv[remote_argc+1] = NULL;
+    remote_argv[remote_argc+2] = NULL;
 
     return prepare_pipes_and_run(argv[1], remote_argv, input_fds,
             input_fds_count, output_fds,


### PR DESCRIPTION
Using dirmngr in a backend qube makes no sense, so forcibly disable it
with '--disable-dirmngr'.