### PR TITLE
Fix the Arch build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ install-vm-deb: install-vm-common
 	make -C tests install-vm-deb
 
 install-vm-fedora: install-vm-common
+install-vm: install-vm-common
 
 clean:
 	$(MAKE) -C src clean


### PR DESCRIPTION
The Arch build was broken because there is no install-vm target in the
Makefile.