### PR TITLE
Make handling of `-o` and `--output` consistent

### DIFF
--- a/gpg-client-wrapper
+++ b/gpg-client-wrapper
@@ -260,8 +260,9 @@ fi
 . /etc/profile.d/qubes-gpg.sh
 # 63 is $fd_for_stdout but bash seems to reject variables here
 
-if  ! ((output)) || [[ "$target" = "-" ]] ; then
-    exec qubes-gpg-client "${options[@]}" 63>&1
+if ((output)); then
+    if [[ "$target" != '-' ]]; then exec > "$target"; fi
+    exec qubes-gpg-client --output=- "${options[@]}" 63>&1
 else
-    exec qubes-gpg-client "${options[@]}" 63>&1 >"$target"
+    exec qubes-gpg-client "${options[@]}" 63>&1
 fi

--- a/gpg-client-wrapper
+++ b/gpg-client-wrapper
@@ -213,15 +213,14 @@ while (( $# )); do
                     options+=("$1" "$2")
                     shift 2
                 elif [[ "$1" =~ ^(-[bacdekKnqst]*)o(.*)$ ]]; then
-                    output=1
                     if (( ${#BASH_REMATCH[1]} > 1 )); then
                         options+=("${BASH_REMATCH[1]}")
                     fi
                     if (( ${#BASH_REMATCH[2]} > 0 )); then
-                        target=${BASH_REMATCH[2]}
+                        set_output "${BASH_REMATCH[2]}"
                         shift
                     elif (( $# >= 2 )); then
-                        target="$2"
+                        set_output "$2"
                         shift 2
                     else
                         printf 'Missing argument to -o\n' >&2

--- a/src/gpg-common.h
+++ b/src/gpg-common.h
@@ -246,7 +246,7 @@ static const struct gpg_command_opt gpg_commands[] = {
     {0, false},
 };
 
-static const char gpg_short_options[] = "+bacdekKnN:qr:R:stu:";
+static const char gpg_short_options[] = "+bacdekKnN:o:qr:R:stu:";
 
 static const struct option gpg_long_options[] = {
     {"always-trust", 0, 0, opt_always_trust},


### PR DESCRIPTION
Have both the C code and wrapper script treat `-o` identically to `--output`.