### PR TITLE
Prevent GPG from launching a photo viewer     

### DIFF
--- a/src/gpg-server.c
+++ b/src/gpg-server.c
@@ -19,7 +19,7 @@ int main(int argc, char *argv[])
     int i;
     int remote_argc, parsed_argc;
     char *(untrusted_remote_argv[COMMAND_MAX_LEN+1]);	// far too big should not harm
-    char *(remote_argv[COMMAND_MAX_LEN+3]);	// far too big should not harm
+    char *(remote_argv[COMMAND_MAX_LEN+4]);	// far too big should not harm
     int input_fds[MAX_FDS], output_fds[MAX_FDS];
     int input_fds_count, output_fds_count;
 
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    memcpy(remote_argv + 3, untrusted_remote_argv + 1,
+    memcpy(remote_argv + 4, untrusted_remote_argv + 1,
            sizeof(untrusted_remote_argv) - sizeof(untrusted_remote_argv[0]));
     /* now options are verified and we get here only when all are allowed */
     remote_argv[0] = argv[1];
@@ -80,8 +80,10 @@ int main(int argc, char *argv[])
     remote_argv[1] = "--no-tty";
     // disable use of dirmngr, which makes no sense in a backend qube
     remote_argv[2] = "--disable-dirmngr";
+    // prevent a photo viewer from being launched
+    remote_argv[3] = "--photo-viewer=/bin/true";
     // Add NULL terminator to argv list
-    remote_argv[remote_argc+2] = NULL;
+    remote_argv[remote_argc+3] = NULL;
 
     return prepare_pipes_and_run(argv[1], remote_argv, input_fds,
             input_fds_count, output_fds,

--- a/tests/splitgpg/tests.py
+++ b/tests/splitgpg/tests.py
@@ -334,6 +334,10 @@ Expire-Date: 0
         stderr = stderr.decode()
         self.assertNotEquals(p.returncode, 0,
             cmd + ' should have failed: ' + stderr)
+        if option == '--list-options' and 'qubes' in prog:
+             self.assertEquals(stderr,
+                 "qubes-gpg-client: Unknown list option '--garbage-1'\n")
+             return True
         for message_fmt in message_fmts:
             if message_fmt.format('--garbage-1') in stderr:
                 return False


### PR DESCRIPTION
Images in GPG keys can come from untrusted sources via
`qubes.GpgImportKey`.  Viewing them in the server is a large and
unnecessary attack surface and should not be allowed.  Programs that
access images via `--attribute-fd` are unaffected.
    
Tested manually; automated tests will be added later in the course of
adding unit tests to split-gpg.

