### PR TITLE
Fix list and verify option processing

### DIFF
--- a/tests/splitgpg/tests.py
+++ b/tests/splitgpg/tests.py
@@ -338,6 +338,10 @@ Expire-Date: 0
              self.assertEquals(stderr,
                  "qubes-gpg-client: Unknown list option '--garbage-1'\n")
              return True
+        if option == '--verify-options' and 'qubes' in prog:
+             self.assertEquals(stderr,
+                 "qubes-gpg-client: Unknown verify option '--garbage-1'\n")
+             return True
         for message_fmt in message_fmts:
             if message_fmt.format('--garbage-1') in stderr:
                 return False


### PR DESCRIPTION
The argument to --verify-options was not sanitized, and the argument to
--list-options was sanitized incorrectly.  For instance, the 'no-' forms
of list options were all rejected, breaking debsign.  Sadness ensued.

Fixes QubesOS/qubes-issues#7378.

Reported-by: Frédéric Pierret <frederic.pierret@qubes-os.org>