### PR TITLE
Make read ends of pipes non-blocking

### DIFF
--- a/src/multiplex.c
+++ b/src/multiplex.c
@@ -2,6 +2,7 @@
  * The Qubes OS Project, http://www.qubes-os.org
  *
  * Copyright (C) 2011  Marek Marczykowski <marmarek@invisiblethingslab.com>
+ * Copyright (C) 2022  Demi Marie Obenour <demi@invisiblethingslab.com>
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
It is possible for split-gpg1 to hang forever because the read ends of
pipes are marked as blocking.  If gpg sends less than BUF_SIZE data to
file descriptor X, and then a large amount of data to file descriptor Y
such that Y’s kernel buffer fills up, deadlock will result.  split-gpg1
will be waiting for gpg to write to X, but gpg will be waiting for
split-gpg1 to read from Y.  This appears to actually happen in practice.

Avoid the problem by setting the read side of all pipes to non-blocking
mode.  There is still a problem with the write side of pipes, but this
would require --command-fd to be in use *and* for gpg to prompt for
input while data is still pending on another file descriptor that gpg
has not closed.  This appears to be rare in practice, and I am not sure
it can happen with any of the command lines that split-gpg1 allows.
Fixing it would require substantial complexity to avoid head-of-line
blocking, and is almost certainly not worthwhile given that split-gpg2
will soon replace split-gpg1.