### PR TITLE
Do not ignore -q and --quiet

### DIFF
--- a/gpg-client-wrapper
+++ b/gpg-client-wrapper
@@ -116,7 +116,7 @@ while (( $# )); do
                 shift
                 ;;
             # Ignored options
-            -q|--quiet|--yes)
+            --yes)
                 shift
                 ;;
             --detach|--detach-sig)

--- a/src/gpg-common.h
+++ b/src/gpg-common.h
@@ -313,6 +313,7 @@ static const struct option gpg_long_options[] = {
     {"pgp6", 0, 0, opt_pgp6},
     {"pgp7", 0, 0, opt_pgp7},
     {"pgp8", 0, 0, opt_pgp8},
+    {"quiet", 0, 0, 'q'},
     {"recipient", 1, 0, 'r'},
     {"rfc2440", 0, 0, opt_rfc2440},
     {"rfc4880", 0, 0, opt_rfc4880},


### PR DESCRIPTION
These are used by Mutt to suppress unwanted output.  Without them, Mutt
waits for the user to press a key before continuing.