### PR TITLE
tests: disable end-of-year message, and similar popups

### DIFF
--- a/tests/splitgpg/tests.py
+++ b/tests/splitgpg/tests.py
@@ -511,6 +511,7 @@ user_pref("mail.identity.id1.fullName", "user");
 user_pref("mail.identity.id1.useremail", "user@localhost");
 user_pref("mail.identity.id1.smtpServer", "smtp1");
 user_pref("mail.identity.id1.compose_html", false);
+user_pref("datareporting.policy.dataSubmissionEnabled", false); // avoid message popups
 """
         imap_server = """
 user_pref("mail.server.server1.userName", "user");


### PR DESCRIPTION
They disrupt tests