### PR TITLE
allow for --default-key option

### DIFF
--- a/gpg-client-wrapper
+++ b/gpg-client-wrapper
@@ -222,7 +222,20 @@ while (( $# )); do
                 options+=("-u" "${1:12}")
                 shift
                 ;;
+            --default-key=*)
+                options+=("-u" "${1:12}")
+                shift
+                ;;
             --sign-with)
+                if (( $# >= 2 )); then
+                    options+=("-u" "$2")
+                    shift 2
+                else # let qubes-gpg-client error out
+                    options+=("$1")
+                    shift
+                fi
+                ;;
+            --default-key)
                 if (( $# >= 2 )); then
                     options+=("-u" "$2")
                     shift 2


### PR DESCRIPTION
`aerc` uses `--default-key` for creating its gpg-command, resulting in something similar to

```bash
gpg --status-fd 2 --log-file /dev/null --batch --armor --detach-sign --default-key [...]
```
(https://github.com/rjarry/aerc/blob/master/lib/crypto/gpg/gpgbin/sign.go et al.)

which failed.

I temporarily changed `/usr/bin/qubes-gpg-client-wrapper` as in this pull request, and things started working (as intended as far as I can tell so far). I don't know if this is the right way to do it, I just copypasted the 2 blocks that looked closest to what aerc was using :grimacing: 