### PR TITLE
tests: adjust dovecot 2.4 detection for F43

### DIFF
--- a/tests/splitgpg/tests.py
+++ b/tests/splitgpg/tests.py
@@ -448,7 +448,7 @@ class TC_10_Thunderbird(SplitGPGBase):
 
         # IMAP configuration
         self.imap_pw = "pass"
-        if self.frontend.run("grep -q mail_driver /etc/dovecot/conf.d/10-mail.conf", wait=True) == 0:
+        if self.frontend.run("grep -rq mail_driver /etc/dovecot/", wait=True) == 0:
             self.frontend.run(
                 'echo "mail_driver = maildir\nmail_path = ~/Mail\nmail_inbox_path = ~/Mail\nuserdb static {\n driver = passwd\n}\npassdb static {\n driver = static\n password=pass\n}" |\
                     tee /etc/dovecot/conf.d/100-mail.conf', wait=True, user="root")


### PR DESCRIPTION
Fedora 43 has different config structure - a single dovecot.conf,
instead of split into conf.d like it's in Debian

QubesOS/qubes-issues#10102