### PR TITLE
Do not install to /var/run in Debian package

### DIFF
--- a/debian/qubes-gpg-split.dirs
+++ b/debian/qubes-gpg-split.dirs
@@ -1,2 +1,1 @@
 usr/lib/qubes-gpg-split
-var/run/qubes-gpg-split


### PR DESCRIPTION
This is d657ab7 but for the Debian package. Installing to /var/run is useless since it's a tmpfs. The package already ships a tmpfiles.d config for it to be created on boot so we can drop the /var/run entirely from `.dirs`.

----

This was noticed because it caused piuparts to fail when we added it as a dependency to some SecureDrop packages: https://github.com/freedomofpress/securedrop-client/pull/3096#issuecomment-3922708587. It fails because it creates a folder under `/var/run`, which is always a symlink to `/run`, so the `.dirs` file should've referenced the latter. But after looking into it, it seems the correct solution is to just remove it entirely, hence this PR.